### PR TITLE
Don't call the transaction closure directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ where
     {
         let id = UniqueId::new();
         probes::transaction__start!(|| (&id, self.id));
-        let result = f(self);
+        let result = Self::TransactionManager::transaction(self, f);
         probes::transaction__done!(|| (&id, self.id));
         result
     }


### PR DESCRIPTION
Pass the transaction closure to Self::TransactionManager::transaction
instead of calling it directly