### PR TITLE
Force tracking to diesel 2.1.6, to follow along with omicron

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,14 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
+    - name: install-pq-mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      env:
+        PQ_LIB_DIR: "$(brew --prefix libpq)/lib"
+        LIBRARY_PATH: "/opt/homebrew/lib:$LIBRARY_PATH"
+        PKG_CONFIG_PATH: "/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH"
+        PATH: "/opt/homebrew/bin:$PATH"
+      run: brew install postgresql
     - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
@@ -46,6 +54,14 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
+    - name: install-pq-mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      env:
+        PQ_LIB_DIR: "$(brew --prefix libpq)/lib"
+        LIBRARY_PATH: "/opt/homebrew/lib:$LIBRARY_PATH"
+        PKG_CONFIG_PATH: "/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH"
+        PATH: "/opt/homebrew/bin:$PATH"
+      run: brew install postgresql
     - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,16 @@ license = "Apache-2.0"
 repository = "https://github.com/oxidecomputer/diesel-dtrace.git"
 
 [dependencies]
-diesel = { version = "2.1.0", features = [ "r2d2", "i-implement-a-third-party-backend-and-opt-into-breaking-changes" ] }
+diesel = { version = "=2.1.6", features = [ "r2d2", "i-implement-a-third-party-backend-and-opt-into-breaking-changes" ] }
 serde = "1"
 usdt = "0.5"
 uuid = { version = ">=0.8.0, <2.0.0", features = [ "v4", "serde" ] }
 
 [dev-dependencies]
-async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel" }
+## match omicron
+async-bb8-diesel = { git = "https://github.com/oxidecomputer/async-bb8-diesel", rev = "ed7ab5ef0513ba303d33efd41d3e9e381169d59b" }
 bb8 = "0.8"
-diesel = { version = "2.1.0", features = [ "postgres", "r2d2", "i-implement-a-third-party-backend-and-opt-into-breaking-changes" ] }
+diesel = { version = "=2.1.6", features = [ "postgres", "r2d2", "i-implement-a-third-party-backend-and-opt-into-breaking-changes" ] }
 tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
 
 [build-dependencies]


### PR DESCRIPTION
Issue:

Pointing at the current `main` branch of async-bb8-diesel (which uses diesel 2.2.*), as it does, causes the build of this lib to use diesel 2.2.* as is, which throws this error on the impl of `Connection`:

```
error[E0046]: not all trait items implemented, missing: `instrumentation`, `set_instrumentation`
   --> /home/zeeshan/.cargo/git/checkouts/diesel-dtrace-b9b9a29f91f682b9/62ef5ca/src/lib.rs:117:1
    |
117 | / impl<C> Connection for DTraceConnection<C>
118 | | where
119 | |     C: Connection<TransactionManager = AnsiTransactionManager>,
120 | |     C::Backend: Default,
121 | |     <C::Backend as Backend>::QueryBuilder: Default,
    | |___________________________________________________^ missing `instrumentation`, `set_instrumentation` in implementation
    |
    = help: implement the missing item: `fn instrumentation(&mut self) -> &mut (dyn Instrumentation + 'static) { todo!() }`
    = help: implement the missing item: `fn set_instrumentation<impl Instrumentation>(&mut self, _: impl Instrumentation) where impl In
strumentation: Instrumentation { todo!() }`
```

Updating this crate's diesel version to 2.2 will cause issues with omicron, as omicron is set to 2.1.6, before the change took shape upstream in diesel. 

Note:
  * async-bb8-diesel without the rev will use 2.2.* diesel dep, adding new trait impl fns