### PR TITLE
Add a `TransactionManager` with more probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf9649c05e0a9dbd6d0b0b8301db5182b972d0fd02f0a7c6736cf632d7c0fd5"
+checksum = "ccf1bedf64cdb9643204a36dd15b19a6ce8e7aa7f7b105868e9f1fad5ffa7d12"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "parking_lot",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ where
         //
         // In any case, it is probably "fine" to pay this cost all the time,
         // even though it's antithetical to the "zero disabled-probe effect"
-        // ethos of DTrace. These methos really just take a pointer to a field
+        // ethos of DTrace. These methods really just take a pointer to a field
         // of `AnsiTransactionManager`, and destructure a few enums. It should
         // be in the noise for any realistic database application.
         let depth = Self::depth(conn);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,14 @@ where
     C::Backend: Default,
     <C::Backend as Backend>::QueryBuilder: Default,
 {
-    type Cursor<'conn, 'query> = C::Cursor< 'conn, 'query> where Self: 'conn;
-    type Row<'conn, 'query> = C::Row<'conn, 'query> where Self: 'conn;
+    type Cursor<'conn, 'query>
+        = C::Cursor<'conn, 'query>
+    where
+        Self: 'conn;
+    type Row<'conn, 'query>
+        = C::Row<'conn, 'query>
+    where
+        Self: 'conn;
 
     fn load<'conn, 'query, T>(
         &'conn mut self,


### PR DESCRIPTION
Adds a `DTraceTransactionManager` type, which provides more complete probes around transaction start / completion