### PR TITLE
Version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-dtrace"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Breaking change to 0.5, because of dependency updates in diesel (2.2 -> 2.3) and usdt (0.5 -> 0.6)